### PR TITLE
Resource-safe export pipeline foundation

### DIFF
--- a/Blender_to_Spine2D_Mesh_Exporter/__init__.py
+++ b/Blender_to_Spine2D_Mesh_Exporter/__init__.py
@@ -1,40 +1,10 @@
-# __init__.py
 # pylint: disable=import-error
-
-"""
-Blender to Spine2D Mesh Exporter
-Copyright (c) 2025 Maxim Sokolenko
-
-This file is part of Blender to Spine2D Mesh Exporter.
-
-Blender to Spine2D Mesh Exporter is free software: you can redistribute it
-and/or modify it under the terms of the GNU General Public License as
-published by the Free Software Foundation, either version 3 of the License,
-or (at your option) any later version.
-
-Blender to Spine2D Mesh Exporter is distributed in the hope that it will
-be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
-of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License along
-with Blender to Spine2D Mesh Exporter. If not, see <https://www.gnu.org/licenses/>.
-This file serves as the main entry point for the 'Blender to Spine2D Mesh Exporter' addon.
-Its primary responsibilities are:
-1.  Addon Metadata: It contains the `bl_info` dictionary, which provides Blender with essential information about the addon, such as its name, author, version, and category.
-2.  Module Management: It imports all the necessary sub-modules of the addon (like `ui`, `main`, `texture_baker`, etc.) and organizes them into a `MODULES` tuple.
-3.  Registration and Unregistration: It defines the `register()` and `unregister()` functions, which are the core hooks Blender uses to load and unload the addon. These functions iterate through the `MODULES` tuple and call the respective `register()` or `unregister()` function within each sub-module, ensuring that all classes, operators, and properties are correctly added to or removed from Blender.
-4.  Logging Initialization: It calls the `setup_logging()` function from the `config` module during registration to configure the addon's logging system.
-5.  Addon Preferences and Uninstallation: It defines a custom addon preferences class (`ModelToSpine2DAddonPreferences`) and an operator (`WM_OT_UninstallAddon`) to provide a user-friendly way to uninstall the addon directly from the Blender preferences window.
-
-ATTENTION: - This file orchestrates the entire addon's lifecycle. The order of modules in the `MODULES` tuple is important, especially for unregistration, which happens in reverse order to prevent dependency errors. Modifying the `register()` or `unregister()` logic can break the addon's ability to load or unload correctly. The `bl_info` dictionary must be kept up-to-date, particularly the "blender" version, to ensure compatibility.
-Author: Maxim Sokolenko
-"""
+"""Blender to Spine2D Mesh Exporter add-on entry point."""
 
 bl_info = {
     "name": "Blender to Spine2D Mesh Exporter",
     "author": "Maxim Sokolenko",
-    "version": (0, 23, 0),
+    "version": (0, 24, 0),
     "blender": (4, 4, 0),
     "location": "View3D > UI > Blender to Spine2D Mesh Exporter",
     "description": "Converts 3D objects into a Spine2D JSON structure",
@@ -42,18 +12,27 @@ bl_info = {
     "category": "3D View",
 }
 
-import bpy
 import logging
 import os
+
+import bpy
 
 from . import config
 from .config import AddonLoggingSettings, LoggingModuleSettings
 
 logger = logging.getLogger("Blender_to_Spine2D_Mesh_Exporter")
 
+# Import the legacy geometry/conversion module first, then install the new
+# resource-safe orchestration before UI and multi-object modules import public
+# functions from ``main``.  This preserves the add-on API during the staged
+# rewrite without duplicating operator identifiers or registration hooks.
+from . import main
+from . import pipeline_v2
+
+pipeline_v2.install(main)
+
 from . import (
     ui,
-    main,
     plane_cut,
     uv_operations,
     utils,
@@ -82,37 +61,34 @@ MODULES = (
 
 
 class WM_OT_UninstallAddon(bpy.types.Operator):
+    """Disable and remove the current add-on package."""
+
     bl_idname = "b2s.uninstall_addon"
     bl_label = "Uninstall Addon"
     module: bpy.props.StringProperty(default=__package__ or __name__)
 
     def execute(self, context):
-        mod = getattr(self, "module", None)
-        if not mod:
+        del context
+        module_name = getattr(self, "module", None)
+        if not module_name:
             base = (__package__ or __name__).split(".")[-1]
-            mods = bpy.context.preferences.addons.keys()
-            candidates = [k for k in mods if k.endswith(base)]
-            mod = candidates[0] if candidates else (__package__ or __name__)
+            installed_modules = bpy.context.preferences.addons.keys()
+            candidates = [key for key in installed_modules if key.endswith(base)]
+            module_name = candidates[0] if candidates else (__package__ or __name__)
 
-        logger.debug(f"Starting addon uninstallation for: {mod}")
+        logger.debug("Starting add-on uninstallation for %s", module_name)
         try:
-            logger.debug(
-                "Attempting to disable addon via bpy.ops.preferences.addon_disable"
-            )
-            bpy.ops.preferences.addon_disable(module=mod)
-        except Exception as e_disable:
-            logger.error(f"Error disabling addon {mod}: {e_disable}")
+            bpy.ops.preferences.addon_disable(module=module_name)
+        except (RuntimeError, TypeError):
+            logger.exception("Failed to disable add-on %s", module_name)
+
         try:
-            logger.debug(
-                "Attempting to remove addon via bpy.ops.preferences.addon_remove"
-            )
-            bpy.ops.preferences.addon_remove(module=mod)
+            bpy.ops.preferences.addon_remove(module=module_name)
             self.report({"INFO"}, "Addon uninstalled successfully.")
-            logger.debug(f"Addon {mod} successfully removed!")
             return {"FINISHED"}
-        except Exception as e_remove:
-            logger.error(f"Error removing addon {mod}: {e_remove}")
-            self.report({"ERROR"}, f"Uninstall failed: {e_remove}")
+        except (RuntimeError, TypeError) as exc:
+            logger.exception("Failed to remove add-on %s", module_name)
+            self.report({"ERROR"}, f"Uninstall failed: {exc}")
             return {"CANCELLED"}
 
 
@@ -121,6 +97,8 @@ MODULE_NAMES_FOR_LOGGING = [
     "config",
     "ui",
     "main",
+    "pipeline_v2",
+    "blender_context",
     "plane_cut",
     "uv_operations",
     "utils",
@@ -133,77 +111,82 @@ MODULE_NAMES_FOR_LOGGING = [
 ]
 
 
-def initialize_logging_preferences(prefs):
+def initialize_logging_preferences(prefs) -> None:
+    """Populate missing per-module logging preferences."""
     if not hasattr(prefs, "logging_settings"):
         return
 
-    if not prefs.logging_settings.log_file_path:
-        default_path = os.path.join(
-            os.path.expanduser("~"), "Blender_to_Spine2D_Mesh_Exporter.log"
+    settings = prefs.logging_settings
+    if not settings.log_file_path:
+        settings.log_file_path = os.path.join(
+            os.path.expanduser("~"),
+            "Blender_to_Spine2D_Mesh_Exporter.log",
         )
-        prefs.logging_settings.log_file_path = default_path
 
-    if not prefs.logging_settings.modules:
-        for name in MODULE_NAMES_FOR_LOGGING:
-            module = prefs.logging_settings.modules.add()
-            module.name = name
-            module.level = "ERROR"
+    existing_names = {
+        module.name for module in settings.modules
+    } if settings.modules else set()
+    for name in MODULE_NAMES_FOR_LOGGING:
+        if name in existing_names:
+            continue
+        module = settings.modules.add()
+        module.name = name
+        module.level = "ERROR"
 
 
 class ModelToSpine2DAddonPreferences(bpy.types.AddonPreferences):
-    bl_idname = __name__
+    """Add-on information, logging controls and uninstall action."""
 
+    bl_idname = __name__
     logging_settings: bpy.props.PointerProperty(type=AddonLoggingSettings)
 
     def update_logging_config(self):
-        from . import config
-
         config.setup_logging()
 
     def draw(self, context):
+        del context
         layout = self.layout
 
-        box = layout.box()
-        box.label(text="Info & Help")
-        box.operator(
-            "wm.url_open", text="Project Website", icon="URL"
+        info_box = layout.box()
+        info_box.label(text="Info & Help")
+        info_box.operator(
+            "wm.url_open",
+            text="Project Website",
+            icon="URL",
         ).url = "https://github.com/maximsokal/Blender_to_Spine_2D_Mesh_Export_Addon"
 
-        box = layout.box()
-        box.label(text="Logging Settings")
-
+        logging_box = layout.box()
+        logging_box.label(text="Logging Settings")
         if not hasattr(self, "logging_settings"):
-            box.label(
-                text="Error initializing logging settings. See console.", icon="ERROR"
+            logging_box.label(
+                text="Error initializing logging settings. See console.",
+                icon="ERROR",
             )
             return
 
-        log_prefs = self.logging_settings
+        settings = self.logging_settings
+        logging_box.prop(settings, "enable_file_logging")
+        if settings.enable_file_logging:
+            logging_box.prop(settings, "log_file_path")
 
-        box.prop(log_prefs, "enable_file_logging")
-        if log_prefs.enable_file_logging:
-            box.prop(log_prefs, "log_file_path")
-
-        box.separator()
-
-        col = box.column(align=True)
-        col.label(text="Module Log Levels:")
-
-        if hasattr(log_prefs, "modules"):
-            for module_setting in log_prefs.modules:
-                row = col.row()
+        logging_box.separator()
+        column = logging_box.column(align=True)
+        column.label(text="Module Log Levels:")
+        if hasattr(settings, "modules"):
+            for module_setting in settings.modules:
+                row = column.row()
                 row.label(text=module_setting.name)
                 row.prop(module_setting, "level", text="")
         else:
-            col.label(text="Error: Modules not registered.", icon="ERROR")
+            column.label(text="Error: Modules not registered.", icon="ERROR")
 
         layout.separator()
         layout.label(text="Uninstall this add-on:")
         try:
-            op = layout.operator("b2s.uninstall_addon", text="Uninstall")
-            op.module = __package__ or __name__
-        except Exception as e:
-            logger.error("Error adding Uninstall button: " + str(e))
+            operator = layout.operator("b2s.uninstall_addon", text="Uninstall")
+            operator.module = __package__ or __name__
+        except (AttributeError, RuntimeError):
+            logger.exception("Failed to draw the uninstall button")
             layout.label(text="Uninstall not available", icon="ERROR")
 
 
@@ -216,43 +199,49 @@ CLASSES_TO_REGISTER = (
 
 
 def register() -> None:
+    """Register preferences first, then add-on modules in dependency order."""
     config._setup_default_logging()
-    logger.debug("Registering Blender_to_Spine2D_Mesh_Exporter Add-on")
+    logger.debug("Registering Blender_to_Spine2D_Mesh_Exporter")
 
     for cls in CLASSES_TO_REGISTER:
         try:
             bpy.utils.register_class(cls)
-        except Exception:
-            logger.exception(f"Failed to register class {cls.__name__}")
+        except (RuntimeError, ValueError):
+            logger.exception("Failed to register class %s", cls.__name__)
 
     for module in MODULES:
         try:
-            if hasattr(module, "register"):
-                module.register()
+            register_function = getattr(module, "register", None)
+            if callable(register_function):
+                register_function()
         except Exception:
-            logger.exception(f"Failed to register module {module.__name__}")
+            logger.exception("Failed to register module %s", module.__name__)
+
     try:
-        prefs = bpy.context.preferences.addons[__name__].preferences
-        initialize_logging_preferences(prefs)
+        preferences = bpy.context.preferences.addons[__name__].preferences
+        initialize_logging_preferences(preferences)
         config.setup_logging()
-        logger.info("User preferences for logging applied.")
-    except Exception as e:
-        logger.error(f"Could not initialize user preferences for logging: {e}")
+        logger.info("User logging preferences applied")
+    except (AttributeError, KeyError, RuntimeError):
+        logger.exception("Could not initialize logging preferences")
 
 
 def unregister() -> None:
-    logger.debug("Unregistering Blender_to_Spine2D_Mesh_Exporter Add-on")
+    """Unregister modules and classes in reverse dependency order."""
+    logger.debug("Unregistering Blender_to_Spine2D_Mesh_Exporter")
     for module in reversed(MODULES):
         try:
-            if hasattr(module, "unregister"):
-                module.unregister()
+            unregister_function = getattr(module, "unregister", None)
+            if callable(unregister_function):
+                unregister_function()
         except Exception:
-            logger.exception(f"Failed to unregister module {module.__name__}")
+            logger.exception("Failed to unregister module %s", module.__name__)
+
     for cls in reversed(CLASSES_TO_REGISTER):
         try:
             bpy.utils.unregister_class(cls)
-        except Exception:
-            logger.exception(f"Failed to unregister class {cls.__name__}")
+        except (RuntimeError, ValueError):
+            logger.exception("Failed to unregister class %s", cls.__name__)
 
 
 if __name__ == "__main__":

--- a/Blender_to_Spine2D_Mesh_Exporter/__init__.py
+++ b/Blender_to_Spine2D_Mesh_Exporter/__init__.py
@@ -1,3 +1,4 @@
+# __init__.py
 # pylint: disable=import-error
 """Blender to Spine2D Mesh Exporter add-on entry point."""
 
@@ -12,20 +13,17 @@ bl_info = {
     "category": "3D View",
 }
 
+import bpy
 import logging
 import os
-
-import bpy
 
 from . import config
 from .config import AddonLoggingSettings, LoggingModuleSettings
 
 logger = logging.getLogger("Blender_to_Spine2D_Mesh_Exporter")
 
-# Import the legacy geometry/conversion module first, then install the new
-# resource-safe orchestration before UI and multi-object modules import public
-# functions from ``main``.  This preserves the add-on API during the staged
-# rewrite without duplicating operator identifiers or registration hooks.
+# Install the resource-safe compatibility layer before modules such as UI and
+# multi-object export bind functions from ``main``.
 from . import main
 from . import pipeline_v2
 
@@ -61,34 +59,31 @@ MODULES = (
 
 
 class WM_OT_UninstallAddon(bpy.types.Operator):
-    """Disable and remove the current add-on package."""
-
     bl_idname = "b2s.uninstall_addon"
     bl_label = "Uninstall Addon"
     module: bpy.props.StringProperty(default=__package__ or __name__)
 
     def execute(self, context):
-        del context
-        module_name = getattr(self, "module", None)
-        if not module_name:
+        mod = getattr(self, "module", None)
+        if not mod:
             base = (__package__ or __name__).split(".")[-1]
-            installed_modules = bpy.context.preferences.addons.keys()
-            candidates = [key for key in installed_modules if key.endswith(base)]
-            module_name = candidates[0] if candidates else (__package__ or __name__)
+            mods = bpy.context.preferences.addons.keys()
+            candidates = [key for key in mods if key.endswith(base)]
+            mod = candidates[0] if candidates else (__package__ or __name__)
 
-        logger.debug("Starting add-on uninstallation for %s", module_name)
+        logger.debug("Starting addon uninstallation for: %s", mod)
         try:
-            bpy.ops.preferences.addon_disable(module=module_name)
-        except (RuntimeError, TypeError):
-            logger.exception("Failed to disable add-on %s", module_name)
+            bpy.ops.preferences.addon_disable(module=mod)
+        except Exception as disable_error:
+            logger.error("Error disabling addon %s: %s", mod, disable_error)
 
         try:
-            bpy.ops.preferences.addon_remove(module=module_name)
+            bpy.ops.preferences.addon_remove(module=mod)
             self.report({"INFO"}, "Addon uninstalled successfully.")
             return {"FINISHED"}
-        except (RuntimeError, TypeError) as exc:
-            logger.exception("Failed to remove add-on %s", module_name)
-            self.report({"ERROR"}, f"Uninstall failed: {exc}")
+        except Exception as remove_error:
+            logger.error("Error removing addon %s: %s", mod, remove_error)
+            self.report({"ERROR"}, f"Uninstall failed: {remove_error}")
             return {"CANCELLED"}
 
 
@@ -111,82 +106,73 @@ MODULE_NAMES_FOR_LOGGING = [
 ]
 
 
-def initialize_logging_preferences(prefs) -> None:
-    """Populate missing per-module logging preferences."""
+def initialize_logging_preferences(prefs):
     if not hasattr(prefs, "logging_settings"):
         return
 
-    settings = prefs.logging_settings
-    if not settings.log_file_path:
-        settings.log_file_path = os.path.join(
-            os.path.expanduser("~"),
-            "Blender_to_Spine2D_Mesh_Exporter.log",
+    if not prefs.logging_settings.log_file_path:
+        prefs.logging_settings.log_file_path = os.path.join(
+            os.path.expanduser("~"), "Blender_to_Spine2D_Mesh_Exporter.log"
         )
 
-    existing_names = {
-        module.name for module in settings.modules
-    } if settings.modules else set()
-    for name in MODULE_NAMES_FOR_LOGGING:
-        if name in existing_names:
-            continue
-        module = settings.modules.add()
-        module.name = name
-        module.level = "ERROR"
+    if not prefs.logging_settings.modules:
+        for name in MODULE_NAMES_FOR_LOGGING:
+            module = prefs.logging_settings.modules.add()
+            module.name = name
+            module.level = "ERROR"
 
 
 class ModelToSpine2DAddonPreferences(bpy.types.AddonPreferences):
-    """Add-on information, logging controls and uninstall action."""
-
     bl_idname = __name__
+
     logging_settings: bpy.props.PointerProperty(type=AddonLoggingSettings)
 
     def update_logging_config(self):
+        from . import config
+
         config.setup_logging()
 
     def draw(self, context):
-        del context
         layout = self.layout
 
-        info_box = layout.box()
-        info_box.label(text="Info & Help")
-        info_box.operator(
-            "wm.url_open",
-            text="Project Website",
-            icon="URL",
+        box = layout.box()
+        box.label(text="Info & Help")
+        box.operator(
+            "wm.url_open", text="Project Website", icon="URL"
         ).url = "https://github.com/maximsokal/Blender_to_Spine_2D_Mesh_Export_Addon"
 
-        logging_box = layout.box()
-        logging_box.label(text="Logging Settings")
+        box = layout.box()
+        box.label(text="Logging Settings")
+
         if not hasattr(self, "logging_settings"):
-            logging_box.label(
-                text="Error initializing logging settings. See console.",
-                icon="ERROR",
+            box.label(
+                text="Error initializing logging settings. See console.", icon="ERROR"
             )
             return
 
-        settings = self.logging_settings
-        logging_box.prop(settings, "enable_file_logging")
-        if settings.enable_file_logging:
-            logging_box.prop(settings, "log_file_path")
+        log_prefs = self.logging_settings
+        box.prop(log_prefs, "enable_file_logging")
+        if log_prefs.enable_file_logging:
+            box.prop(log_prefs, "log_file_path")
 
-        logging_box.separator()
-        column = logging_box.column(align=True)
-        column.label(text="Module Log Levels:")
-        if hasattr(settings, "modules"):
-            for module_setting in settings.modules:
-                row = column.row()
+        box.separator()
+        col = box.column(align=True)
+        col.label(text="Module Log Levels:")
+        if hasattr(log_prefs, "modules"):
+            for module_setting in log_prefs.modules:
+                row = col.row()
                 row.label(text=module_setting.name)
                 row.prop(module_setting, "level", text="")
         else:
-            column.label(text="Error: Modules not registered.", icon="ERROR")
+            col.label(text="Error: Modules not registered.", icon="ERROR")
 
         layout.separator()
         layout.label(text="Uninstall this add-on:")
         try:
             operator = layout.operator("b2s.uninstall_addon", text="Uninstall")
             operator.module = __package__ or __name__
-        except (AttributeError, RuntimeError):
-            logger.exception("Failed to draw the uninstall button")
+        except Exception as error:
+            logger.error("Error adding Uninstall button: %s", error)
             layout.label(text="Uninstall not available", icon="ERROR")
 
 
@@ -199,48 +185,44 @@ CLASSES_TO_REGISTER = (
 
 
 def register() -> None:
-    """Register preferences first, then add-on modules in dependency order."""
     config._setup_default_logging()
-    logger.debug("Registering Blender_to_Spine2D_Mesh_Exporter")
+    logger.debug("Registering Blender_to_Spine2D_Mesh_Exporter Add-on")
 
     for cls in CLASSES_TO_REGISTER:
         try:
             bpy.utils.register_class(cls)
-        except (RuntimeError, ValueError):
+        except Exception:
             logger.exception("Failed to register class %s", cls.__name__)
 
     for module in MODULES:
         try:
-            register_function = getattr(module, "register", None)
-            if callable(register_function):
-                register_function()
+            if hasattr(module, "register"):
+                module.register()
         except Exception:
             logger.exception("Failed to register module %s", module.__name__)
 
     try:
-        preferences = bpy.context.preferences.addons[__name__].preferences
-        initialize_logging_preferences(preferences)
+        prefs = bpy.context.preferences.addons[__name__].preferences
+        initialize_logging_preferences(prefs)
         config.setup_logging()
-        logger.info("User logging preferences applied")
-    except (AttributeError, KeyError, RuntimeError):
-        logger.exception("Could not initialize logging preferences")
+        logger.info("User preferences for logging applied.")
+    except Exception as error:
+        logger.error("Could not initialize user preferences for logging: %s", error)
 
 
 def unregister() -> None:
-    """Unregister modules and classes in reverse dependency order."""
-    logger.debug("Unregistering Blender_to_Spine2D_Mesh_Exporter")
+    logger.debug("Unregistering Blender_to_Spine2D_Mesh_Exporter Add-on")
     for module in reversed(MODULES):
         try:
-            unregister_function = getattr(module, "unregister", None)
-            if callable(unregister_function):
-                unregister_function()
+            if hasattr(module, "unregister"):
+                module.unregister()
         except Exception:
             logger.exception("Failed to unregister module %s", module.__name__)
 
     for cls in reversed(CLASSES_TO_REGISTER):
         try:
             bpy.utils.unregister_class(cls)
-        except (RuntimeError, ValueError):
+        except Exception:
             logger.exception("Failed to unregister class %s", cls.__name__)
 
 

--- a/Blender_to_Spine2D_Mesh_Exporter/blender_context.py
+++ b/Blender_to_Spine2D_Mesh_Exporter/blender_context.py
@@ -1,0 +1,201 @@
+# pylint: disable=import-error
+"""Safe Blender context and BMesh resource helpers.
+
+The exporter performs many stateful Blender operations.  This module keeps
+ownership rules explicit:
+
+* every BMesh created with :func:`bmesh.new` is freed exactly once;
+* edit BMeshes returned by ``bmesh.from_edit_mesh`` are never handled here;
+* active object, selection and object mode can be restored after a pipeline;
+* temporary objects are removed through the data API, not selection operators.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from dataclasses import dataclass
+import logging
+from typing import Iterator
+
+import bpy
+import bmesh
+
+logger = logging.getLogger(__name__)
+
+
+def _object_is_alive(obj: object | None) -> bool:
+    """Return ``True`` when *obj* still refers to a linked Blender object."""
+    if obj is None:
+        return False
+    try:
+        name = obj.name
+        stored = bpy.data.objects.get(name)
+        return stored is obj or stored == obj
+    except (AttributeError, ReferenceError, RuntimeError):
+        return False
+
+
+def _safe_mode_set(mode: str) -> bool:
+    """Set object mode only when Blender's operator context allows it."""
+    try:
+        poll = getattr(bpy.ops.object.mode_set, "poll", None)
+        if callable(poll) and not poll():
+            return False
+        bpy.ops.object.mode_set(mode=mode)
+        return True
+    except (AttributeError, RuntimeError, TypeError):
+        logger.debug("Unable to switch Blender mode to %s", mode, exc_info=True)
+        return False
+
+
+@dataclass(slots=True)
+class BlenderContextSnapshot:
+    """Minimal scene state required to restore the user's working context."""
+
+    active_object: object | None
+    selected_objects: tuple[object, ...]
+    active_mode: str | None
+
+    @classmethod
+    def capture(cls) -> "BlenderContextSnapshot":
+        try:
+            active = bpy.context.view_layer.objects.active
+        except (AttributeError, RuntimeError):
+            active = getattr(bpy.context, "active_object", None)
+
+        try:
+            selected = tuple(bpy.context.selected_objects)
+        except (AttributeError, RuntimeError, TypeError):
+            selected = ()
+
+        try:
+            mode = active.mode if active is not None else None
+        except (AttributeError, ReferenceError, RuntimeError):
+            mode = None
+
+        return cls(active_object=active, selected_objects=selected, active_mode=mode)
+
+    def restore(self) -> None:
+        """Best-effort restoration that never masks the export exception."""
+        try:
+            current_active = getattr(bpy.context.view_layer.objects, "active", None)
+            current_mode = getattr(current_active, "mode", "OBJECT")
+            if current_active is not None and current_mode != "OBJECT":
+                _safe_mode_set("OBJECT")
+
+            try:
+                currently_selected = tuple(bpy.context.selected_objects)
+            except (AttributeError, RuntimeError, TypeError):
+                currently_selected = ()
+
+            for obj in currently_selected:
+                if _object_is_alive(obj):
+                    try:
+                        obj.select_set(False)
+                    except (AttributeError, ReferenceError, RuntimeError):
+                        logger.debug("Failed to deselect %r", obj, exc_info=True)
+
+            for obj in self.selected_objects:
+                if _object_is_alive(obj):
+                    try:
+                        obj.select_set(True)
+                    except (AttributeError, ReferenceError, RuntimeError):
+                        logger.debug("Failed to reselect %r", obj, exc_info=True)
+
+            if _object_is_alive(self.active_object):
+                bpy.context.view_layer.objects.active = self.active_object
+                if self.active_mode and self.active_mode != "OBJECT":
+                    _safe_mode_set(self.active_mode)
+            else:
+                bpy.context.view_layer.objects.active = None
+        except Exception:  # Context restoration must never hide primary failures.
+            logger.exception("Failed to restore Blender context")
+
+
+def activate_object(obj: object, *, ensure_object_mode: bool = True) -> None:
+    """Make a linked object active and exclusively selected."""
+    if not _object_is_alive(obj):
+        raise ReferenceError("Cannot activate an object that is not linked to bpy.data")
+
+    current_active = getattr(bpy.context.view_layer.objects, "active", None)
+    current_mode = getattr(current_active, "mode", "OBJECT")
+    if ensure_object_mode and current_active is not None and current_mode != "OBJECT":
+        if not _safe_mode_set("OBJECT"):
+            raise RuntimeError("Blender could not switch to OBJECT mode")
+
+    try:
+        selected = tuple(bpy.context.selected_objects)
+    except (AttributeError, RuntimeError, TypeError):
+        selected = ()
+
+    for selected_obj in selected:
+        if _object_is_alive(selected_obj):
+            selected_obj.select_set(False)
+
+    obj.select_set(True)
+    bpy.context.view_layer.objects.active = obj
+
+
+@contextmanager
+def managed_bmesh(mesh: object, *, write_back: bool = False) -> Iterator[object]:
+    """Yield a new BMesh and free it exactly once.
+
+    This helper is only for BMeshes created through ``bmesh.new()``.  It must
+    never be used with ``bmesh.from_edit_mesh()``.
+    """
+    if mesh is None:
+        raise TypeError("mesh must not be None")
+
+    bm = bmesh.new()
+    try:
+        bm.from_mesh(mesh)
+        yield bm
+        if write_back:
+            bm.to_mesh(mesh)
+            update = getattr(mesh, "update", None)
+            if callable(update):
+                update()
+    finally:
+        bm.free()
+
+
+def triangulate_mesh_data(mesh: object) -> None:
+    """Triangulate a Mesh datablock and persist the result safely."""
+    with managed_bmesh(mesh, write_back=True) as bm:
+        faces = list(bm.faces)
+        if not faces:
+            return
+        bmesh.ops.triangulate(
+            bm,
+            faces=faces,
+            quad_method="BEAUTY",
+            ngon_method="BEAUTY",
+        )
+
+
+def remove_object_if_alive(obj: object | None) -> bool:
+    """Remove a linked object and return whether removal was performed."""
+    if not _object_is_alive(obj):
+        return False
+    try:
+        bpy.data.objects.remove(obj, do_unlink=True)
+        return True
+    except (ReferenceError, RuntimeError):
+        logger.warning("Failed to remove temporary object %r", obj, exc_info=True)
+        return False
+
+
+def scene_bool(name: str, default: bool = False) -> bool:
+    """Read a registered property or custom scene property without assumptions."""
+    scene = getattr(bpy.context, "scene", None)
+    if scene is None:
+        return default
+
+    try:
+        value = getattr(scene, name)
+    except (AttributeError, RuntimeError):
+        try:
+            value = scene.get(name, default)
+        except (AttributeError, RuntimeError, TypeError):
+            return default
+    return bool(value)

--- a/Blender_to_Spine2D_Mesh_Exporter/blender_manifest.toml
+++ b/Blender_to_Spine2D_Mesh_Exporter/blender_manifest.toml
@@ -1,7 +1,7 @@
 schema_version = "1.0.0"
 
 id = "Blender_to_Spine2D_Mesh_Exporter"
-version = "0.23.0"
+version = "0.24.0"
 name = "Blender to Spine2D Mesh Exporter"
 maintainer = "Maxim Sokolenko"
 blender_version_min = "4.4.0"

--- a/Blender_to_Spine2D_Mesh_Exporter/pipeline_v2.py
+++ b/Blender_to_Spine2D_Mesh_Exporter/pipeline_v2.py
@@ -1,0 +1,673 @@
+# pylint: disable=import-error,too-many-locals,too-many-branches,too-many-statements
+"""Resource-safe export pipeline used as the v0.24 migration bridge.
+
+The legacy ``main.py`` still contains geometry and Spine conversion routines.
+This module extracts orchestration and ownership from that file while keeping
+its public API stable.  ``install()`` replaces only the unsafe entry points;
+callers can continue importing them from ``main`` during the staged rewrite.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from copy import deepcopy
+from dataclasses import dataclass, field
+import logging
+import os
+from math import sqrt
+from typing import Iterable, Sequence
+
+import bpy
+import bmesh
+
+from .blender_context import (
+    BlenderContextSnapshot,
+    activate_object,
+    managed_bmesh,
+    remove_object_if_alive,
+    scene_bool,
+)
+
+logger = logging.getLogger(__name__)
+_LEGACY_MAIN = None
+
+
+class ExportPipelineError(RuntimeError):
+    """Expected pipeline failure with a message suitable for the Blender log."""
+
+
+def _legacy():
+    if _LEGACY_MAIN is None:
+        raise RuntimeError("pipeline_v2.install(main_module) was not called")
+    return _LEGACY_MAIN
+
+
+def _mesh_object(obj: object, argument_name: str = "obj") -> object:
+    if obj is None:
+        raise TypeError(f"{argument_name} must not be None")
+    if getattr(obj, "type", None) != "MESH":
+        raise TypeError(f"{argument_name} must be a Blender MESH object")
+    if getattr(obj, "data", None) is None:
+        raise TypeError(f"{argument_name}.data must be a Mesh datablock")
+    return obj
+
+
+def _normalise_edges(segmentation_data: Iterable[Sequence[int]] | None) -> set[frozenset[int]]:
+    normalised: set[frozenset[int]] = set()
+    if not segmentation_data:
+        return normalised
+
+    for index, pair in enumerate(segmentation_data):
+        if not isinstance(pair, (tuple, list)) or len(pair) != 2:
+            logger.warning("Ignoring malformed segmentation edge #%d: %r", index, pair)
+            continue
+        try:
+            first, second = int(pair[0]), int(pair[1])
+        except (TypeError, ValueError):
+            logger.warning("Ignoring non-integer segmentation edge #%d: %r", index, pair)
+            continue
+        if first == second or first < 0 or second < 0:
+            logger.warning("Ignoring degenerate segmentation edge #%d: %r", index, pair)
+            continue
+        normalised.add(frozenset((first, second)))
+    return normalised
+
+
+def apply_segmentation_seams(obj, segmentation_data) -> None:
+    """Apply segment boundaries and always release the temporary BMesh."""
+    obj = _mesh_object(obj)
+    target_edges = _normalise_edges(segmentation_data)
+    if not target_edges:
+        logger.debug("No segmentation seams to apply to %s", obj.name)
+        return
+
+    marked = 0
+    with managed_bmesh(obj.data, write_back=True) as bm:
+        bm.verts.ensure_lookup_table()
+        bm.edges.ensure_lookup_table()
+        for edge in bm.edges:
+            key = frozenset((edge.verts[0].index, edge.verts[1].index))
+            if key in target_edges:
+                edge.seam = True
+                marked += 1
+
+    missing = len(target_edges) - marked
+    if missing > 0:
+        logger.warning(
+            "Applied %d of %d segmentation seams to %s; %d edges were not found",
+            marked,
+            len(target_edges),
+            obj.name,
+            missing,
+        )
+    else:
+        logger.debug("Applied %d segmentation seams to %s", marked, obj.name)
+
+
+def copy_orig_face_id_layer(source_obj, target_obj) -> bool:
+    """Copy ``orig_face_id`` by face index with deterministic BMesh cleanup."""
+    source_obj = _mesh_object(source_obj, "source_obj")
+    target_obj = _mesh_object(target_obj, "target_obj")
+
+    with managed_bmesh(source_obj.data) as source_bm:
+        source_bm.faces.ensure_lookup_table()
+        source_layer = source_bm.faces.layers.int.get("orig_face_id")
+        if source_layer is None:
+            logger.warning("%s has no orig_face_id face layer", source_obj.name)
+            return False
+
+        source_values = [face[source_layer] for face in source_bm.faces]
+
+    with managed_bmesh(target_obj.data, write_back=True) as target_bm:
+        target_bm.faces.ensure_lookup_table()
+        target_layer = target_bm.faces.layers.int.get("orig_face_id")
+        if target_layer is None:
+            target_layer = target_bm.faces.layers.int.new("orig_face_id")
+
+        copy_count = min(len(source_values), len(target_bm.faces))
+        for face_index in range(copy_count):
+            target_bm.faces[face_index][target_layer] = source_values[face_index]
+
+        if len(source_values) != len(target_bm.faces):
+            logger.warning(
+                "orig_face_id face-count mismatch: %s=%d, %s=%d; copied %d",
+                source_obj.name,
+                len(source_values),
+                target_obj.name,
+                len(target_bm.faces),
+                copy_count,
+            )
+
+    return True
+
+
+def get_texture_dimensions(obj, default_texture_width, default_texture_height):
+    """Read the first image texture size without suppressing unexpected errors."""
+    width = int(default_texture_width)
+    height = int(default_texture_height)
+
+    try:
+        material = getattr(obj, "active_material", None)
+        node_tree = getattr(material, "node_tree", None) if material else None
+        nodes = getattr(node_tree, "nodes", ()) if node_tree else ()
+        for node in nodes:
+            image = getattr(node, "image", None)
+            if getattr(node, "type", None) == "TEX_IMAGE" and image is not None:
+                image_width, image_height = image.size[:2]
+                width, height = int(image_width), int(image_height)
+                break
+    except (AttributeError, KeyError, RuntimeError, TypeError, ValueError):
+        logger.warning("Failed to read texture dimensions; defaults are used", exc_info=True)
+
+    return width, height
+
+
+def triangulate_mesh(obj):
+    """Return a triangulated BMesh; ownership is transferred to the caller."""
+    obj = _mesh_object(obj)
+    bm = bmesh.new()
+    try:
+        bm.from_mesh(obj.data)
+        faces = list(bm.faces)
+        if faces:
+            bmesh.ops.triangulate(
+                bm,
+                faces=faces,
+                quad_method="BEAUTY",
+                ngon_method="BEAUTY",
+            )
+        return bm
+    except Exception:
+        bm.free()
+        logger.exception("Failed to triangulate BMesh for %s", obj.name)
+        raise
+
+
+def collect_vertices(bm, obj_name):
+    """Collect UV/position data without taking ownership of *bm*.
+
+    The caller that received the BMesh from :func:`triangulate_mesh` is solely
+    responsible for ``bm.free()``.  This removes the legacy double-free path.
+    """
+    if bm is None:
+        raise TypeError("bm must not be None")
+
+    uv_layer = bm.loops.layers.uv.active
+    if uv_layer is None:
+        raise ExportPipelineError(f"UV layer not found after triangulation: {obj_name}")
+
+    bm.verts.ensure_lookup_table()
+    bm.faces.ensure_lookup_table()
+
+    triangles: list[int] = []
+    vertex_map: dict[tuple[float, float, int], int] = {}
+    vertex_list: list[tuple[float, float]] = []
+    vertex_positions_list: list[object] = []
+
+    for face in bm.faces:
+        if len(face.loops) != 3:
+            raise ExportPipelineError(
+                f"Triangulated BMesh contains a {len(face.loops)}-sided face: {obj_name}"
+            )
+        for loop in face.loops:
+            uv = loop[uv_layer].uv
+            key = (round(float(uv.x), 6), round(float(uv.y), 6), int(loop.vert.index))
+            vertex_index = vertex_map.get(key)
+            if vertex_index is None:
+                vertex_index = len(vertex_list)
+                vertex_map[key] = vertex_index
+                vertex_list.append((float(uv.x), float(uv.y)))
+                vertex_positions_list.append(loop.vert.co.copy())
+            triangles.append(vertex_index)
+
+    if len(triangles) % 3:
+        raise ExportPipelineError(
+            f"Triangle index list for {obj_name} has invalid length {len(triangles)}"
+        )
+
+    logger.debug(
+        "Collected %d unique vertices and %d triangles from %s",
+        len(vertex_list),
+        len(triangles) // 3,
+        obj_name,
+    )
+    return vertex_list, vertex_positions_list, triangles, obj_name
+
+
+def calculate_stretch_values(obj):
+    """Calculate stretch values while freeing the BMesh on every exit path."""
+    obj = _mesh_object(obj)
+    legacy = _legacy()
+
+    with managed_bmesh(obj.data) as bm:
+        uv_layer = bm.loops.layers.uv.active
+        if uv_layer is None:
+            logger.debug("No active UV layer found for stretch calculation on %s", obj.name)
+            return None
+
+        bm.verts.ensure_lookup_table()
+        bm.faces.ensure_lookup_table()
+        vertex_groups = defaultdict(list)
+        precision = 4
+        for vert in bm.verts:
+            vertex_groups[round(float(vert.co.z), precision)].append(vert)
+
+        processed_faces: set[int] = set()
+        group_areas = defaultdict(lambda: {"area_3d": 0.0, "area_uv": 0.0})
+        minimum_area = 1e-4
+
+        for vertices in vertex_groups.values():
+            for vert in vertices:
+                for face in vert.link_faces:
+                    if face.index in processed_faces:
+                        continue
+                    processed_faces.add(face.index)
+
+                    z_values = [round(float(v.co.z), precision) for v in face.verts]
+                    z_key = z_values[0] if all(z == z_values[0] for z in z_values) else round(
+                        sum(z_values) / len(z_values), precision
+                    )
+                    area_3d = float(face.calc_area())
+                    area_uv = 0.5 * abs(
+                        sum(
+                            face.loops[index][uv_layer].uv.x
+                            * face.loops[index - 1][uv_layer].uv.y
+                            - face.loops[index - 1][uv_layer].uv.x
+                            * face.loops[index][uv_layer].uv.y
+                            for index in range(len(face.loops))
+                        )
+                    )
+                    if area_3d <= minimum_area or area_uv <= minimum_area:
+                        logger.warning(
+                            "Face %d on %s has too small areas: 3D=%s UV=%s",
+                            face.index,
+                            obj.name,
+                            area_3d,
+                            area_uv,
+                        )
+                        continue
+                    group_areas[z_key]["area_3d"] += area_3d
+                    group_areas[z_key]["area_uv"] += area_uv
+
+    raw_stretch = {}
+    for z_key, areas in group_areas.items():
+        if areas["area_3d"] > minimum_area and areas["area_uv"] > minimum_area:
+            raw_stretch[z_key] = sqrt(areas["area_3d"] / areas["area_uv"])
+        else:
+            raw_stretch[z_key] = 1.0
+
+    smoothed = legacy.smooth_stretch_values(raw_stretch, window_size=5)
+    limited = legacy.limit_stretch_changes(smoothed, max_change=0.1)
+    return {z_key: max(0.5, min(2.0, value)) for z_key, value in limited.items()}
+
+
+def apply_transformations(obj) -> None:
+    """Apply rotation/scale to exactly *obj* and restore prior context."""
+    obj = _mesh_object(obj)
+    snapshot = BlenderContextSnapshot.capture()
+    try:
+        activate_object(obj)
+        result = bpy.ops.object.transform_apply(location=False, rotation=True, scale=True)
+        if isinstance(result, set) and "CANCELLED" in result:
+            raise ExportPipelineError(f"Transform apply was cancelled for {obj.name}")
+    finally:
+        snapshot.restore()
+
+
+@dataclass(slots=True)
+class ExportSession:
+    """Own temporary datablocks and the user's Blender context for one export."""
+
+    source_obj: object
+    context: BlenderContextSnapshot = field(default_factory=BlenderContextSnapshot.capture)
+    temporary_objects: list[object] = field(default_factory=list)
+    segment_objects: list[object] = field(default_factory=list)
+    original_copy: object | None = None
+    textured_obj: object | None = None
+    created_source_uv_name: str | None = None
+    previous_face_id_map: object | None = None
+    had_face_id_map: bool = False
+
+    def track(self, obj: object | None) -> object | None:
+        if obj is not None and all(existing is not obj for existing in self.temporary_objects):
+            self.temporary_objects.append(obj)
+        return obj
+
+    def restore_source_metadata(self) -> None:
+        data = getattr(self.source_obj, "data", None)
+        if data is None:
+            return
+
+        if self.created_source_uv_name:
+            try:
+                layer = data.uv_layers.get(self.created_source_uv_name)
+                if layer is not None:
+                    data.uv_layers.remove(layer)
+            except (AttributeError, ReferenceError, RuntimeError):
+                logger.warning("Failed to remove temporary source UV layer", exc_info=True)
+
+        try:
+            if self.had_face_id_map:
+                data["face_id_map"] = self.previous_face_id_map
+            elif "face_id_map" in data:
+                del data["face_id_map"]
+        except (AttributeError, KeyError, ReferenceError, RuntimeError, TypeError):
+            logger.warning("Failed to restore face_id_map metadata", exc_info=True)
+
+    def cleanup(self, preserve_debug_artifacts: bool) -> None:
+        legacy = _legacy()
+        if preserve_debug_artifacts:
+            logger.info(
+                "Debug artifacts preserved explicitly by scene property "
+                "spine2d_preserve_debug_artifacts"
+            )
+            return
+
+        if self.segment_objects and self.original_copy is not None:
+            try:
+                legacy.delete_segment_artifacts(self.segment_objects, self.original_copy)
+            except Exception:
+                logger.exception("Failed to delete segment artifacts")
+
+        removed_ids: set[int] = set()
+        removed_count = 0
+        for obj in reversed(self.temporary_objects):
+            identity = id(obj)
+            if identity in removed_ids:
+                continue
+            removed_ids.add(identity)
+            if remove_object_if_alive(obj):
+                removed_count += 1
+        logger.info("Removed %d temporary Blender objects", removed_count)
+
+
+def _resolve_output_directory(output_dir: str | None) -> str:
+    legacy = _legacy()
+    candidate = None
+    if output_dir:
+        try:
+            candidate = bpy.path.abspath(output_dir)
+        except (AttributeError, RuntimeError, TypeError):
+            candidate = output_dir
+        if isinstance(candidate, bytes):
+            candidate = candidate.decode("utf-8")
+        if candidate and os.path.isdir(candidate):
+            return candidate
+
+    candidate = legacy.get_default_output_dir()
+    if isinstance(candidate, bytes):
+        candidate = candidate.decode("utf-8")
+    if not isinstance(candidate, str) or not candidate:
+        raise ExportPipelineError("Unable to resolve the JSON output directory")
+    os.makedirs(candidate, exist_ok=True)
+    return candidate
+
+
+def _ensure_source_uv(obj, session: ExportSession) -> str:
+    uv_layers = obj.data.uv_layers
+    if not uv_layers:
+        before_names = {layer.name for layer in uv_layers}
+        _legacy().smart_uv_project(obj, obj.name)
+        after_names = {layer.name for layer in obj.data.uv_layers}
+        created_names = sorted(after_names - before_names)
+        if created_names:
+            session.created_source_uv_name = created_names[0]
+
+    active = obj.data.uv_layers.active
+    if active is None and obj.data.uv_layers:
+        active = obj.data.uv_layers[0]
+    if active is None:
+        raise ExportPipelineError(f"Object {obj.name} has no usable UV map")
+    return active.name
+
+
+def _copy_seams(source_obj, target_obj) -> None:
+    seam_keys: set[tuple[int, int]] = set()
+    with managed_bmesh(source_obj.data) as source_bm:
+        source_bm.verts.ensure_lookup_table()
+        source_bm.edges.ensure_lookup_table()
+        for edge in source_bm.edges:
+            if edge.seam:
+                seam_keys.add(tuple(sorted((edge.verts[0].index, edge.verts[1].index))))
+
+    if not seam_keys:
+        return
+
+    with managed_bmesh(target_obj.data, write_back=True) as target_bm:
+        target_bm.verts.ensure_lookup_table()
+        target_bm.edges.ensure_lookup_table()
+        for edge in target_bm.edges:
+            key = tuple(sorted((edge.verts[0].index, edge.verts[1].index)))
+            edge.seam = key in seam_keys
+
+
+def _new_segment_objects(before_ids: set[int], base_name: str) -> list[object]:
+    result = []
+    for obj in bpy.context.scene.objects:
+        try:
+            pointer = int(obj.as_pointer())
+        except (AttributeError, ReferenceError, RuntimeError, TypeError, ValueError):
+            pointer = id(obj)
+        if pointer in before_ids:
+            continue
+        if obj.name.startswith(f"{base_name}_Segment_"):
+            result.append(obj)
+    return sorted(result, key=lambda item: item.name)
+
+
+def _object_ids() -> set[int]:
+    result: set[int] = set()
+    for obj in bpy.context.scene.objects:
+        try:
+            result.add(int(obj.as_pointer()))
+        except (AttributeError, ReferenceError, RuntimeError, TypeError, ValueError):
+            result.add(id(obj))
+    return result
+
+
+def _prepare_textured_uv(textured_obj, segmentation_data) -> str:
+    legacy = _legacy()
+    if segmentation_data:
+        uv_name = legacy.unwrap_respecting_seams(
+            textured_obj,
+            method="ANGLE_BASED",
+            margin=0.001,
+        )
+        if not uv_name:
+            uv_name = legacy.smart_uv_project(textured_obj, textured_obj.name)
+    else:
+        uv_name = legacy.smart_uv_project(textured_obj, textured_obj.name)
+
+    if textured_obj.data.uv_layers:
+        active = textured_obj.data.uv_layers.active or textured_obj.data.uv_layers[0]
+        active.name = "UVMap_for_texturing"
+        return active.name
+    if isinstance(uv_name, str) and uv_name:
+        return uv_name
+    raise ExportPipelineError(f"Textured object {textured_obj.name} has no UV layer")
+
+
+def _export_segments(
+    segment_objects,
+    original_copy,
+    textured_obj,
+    texture_width,
+    texture_height,
+    z_groups_info,
+    original_z_groups,
+    save_directory,
+    original_world_location,
+):
+    legacy = _legacy()
+    results = []
+    original_uv_pairs = None
+    textured_uv_pairs = None
+
+    for segment in segment_objects:
+        is_original = segment is original_copy or segment.name == original_copy.name
+        if not is_original and original_uv_pairs is None:
+            raise ExportPipelineError("Original UV/3D pairs were not generated before segments")
+        if not is_original and textured_uv_pairs is None:
+            raise ExportPipelineError("Textured UV/3D pairs were not generated before segments")
+
+        result = legacy._export_segment(
+            segment,
+            original_copy.name,
+            textured_obj=textured_obj,
+            TEXTURE_WIDTH=texture_width,
+            TEXTURE_HEIGHT=texture_height,
+            original_uv3d_pairs=original_uv_pairs,
+            textured_uv3d_pairs_global=textured_uv_pairs,
+            z_groups_info=z_groups_info if is_original else {},
+            original_z_groups=original_z_groups,
+            output_dir=save_directory,
+            local_z_groups=original_z_groups if is_original else None,
+            world_location=original_world_location,
+        )
+        if not result:
+            raise ExportPipelineError(f"Segment export failed: {segment.name}")
+        results.append(result)
+
+        if is_original:
+            original_uv_pairs = result.get("_uv3d_pairs")
+            textured_uv_pairs = result.get("textured_uv3d_pairs")
+            if not original_uv_pairs or not textured_uv_pairs:
+                raise ExportPipelineError("Original export did not produce UV/3D correspondence")
+
+    return results
+
+
+def save_uv_as_json(obj, TEXTURE_WIDTH: int, TEXTURE_HEIGHT: int, output_dir: str | None = None):
+    """Run one export with deterministic cleanup and context restoration."""
+    obj = _mesh_object(obj)
+    texture_width = int(TEXTURE_WIDTH)
+    texture_height = int(TEXTURE_HEIGHT)
+    if texture_width <= 0 or texture_height <= 0:
+        raise ValueError("Texture dimensions must be positive integers")
+
+    legacy = _legacy()
+    session = ExportSession(source_obj=obj)
+    preserve_debug = scene_bool("spine2d_preserve_debug_artifacts", False)
+
+    try:
+        original_world_location = obj.matrix_world.translation.copy()
+        save_directory = _resolve_output_directory(output_dir)
+
+        # UV operators are context-sensitive.  Activate the explicit source
+        # object instead of assuming that the caller prepared Blender context.
+        activate_object(obj)
+        source_uv_name = _ensure_source_uv(obj, session)
+
+        try:
+            session.had_face_id_map = "face_id_map" in obj.data
+            if session.had_face_id_map:
+                session.previous_face_id_map = deepcopy(obj.data["face_id_map"])
+        except (KeyError, TypeError, AttributeError):
+            session.had_face_id_map = False
+        legacy.assign_face_ids(obj)
+
+        original_copy = obj.copy()
+        original_copy.data = obj.data.copy()
+        original_copy.name = f"{obj.name}_copy_for_uv"
+        bpy.context.collection.objects.link(original_copy)
+        session.original_copy = session.track(original_copy)
+
+        _copy_seams(obj, original_copy)
+        activate_object(original_copy)
+
+        post_unwrap_info = legacy.main_preprocessing(original_copy)
+        if not post_unwrap_info:
+            raise ExportPipelineError(f"Preprocessing failed for {original_copy.name}")
+        z_groups_info = post_unwrap_info.get("z_groups_info", {})
+        original_z_groups = sorted(z_groups_info.keys())
+
+        scene = bpy.context.scene
+        seam_mode = scene.spine2d_seam_maker_mode
+        angle_limit = float(scene.spine2d_angle_limit)
+        objects_before_cut = _object_ids()
+        segmentation_data = legacy.plane_cut.execute_smart_cut(
+            original_copy,
+            angle_limit=angle_limit,
+            seam_mode=seam_mode,
+            capture_uv_data=True,
+        )
+        if segmentation_data is None:
+            segmentation_data = []
+        apply_segmentation_seams(original_copy, segmentation_data)
+
+        base_name = original_copy.name.removesuffix("_copy_for_uv")
+        generated_segments = _new_segment_objects(objects_before_cut, base_name)
+        for segment in generated_segments:
+            session.track(segment)
+        session.segment_objects = [original_copy, *generated_segments]
+
+        textured_obj, _seams_info = legacy.mark_seams_on_copy(obj, segmentation_data)
+        if textured_obj is None:
+            raise ExportPipelineError("Failed to create the texturing copy")
+        session.textured_obj = session.track(textured_obj)
+
+        if "uv_island_segments" in original_copy:
+            legacy.transfer_uv_islands_between_objects(original_copy, textured_obj)
+
+        copy_orig_face_id_layer(original_copy, textured_obj)
+        target_uv_name = _prepare_textured_uv(textured_obj, segmentation_data)
+
+        if not legacy.bake_textures_for_object(
+            textured_obj,
+            target_uv_name,
+            obj,
+            source_uv_name,
+        ):
+            raise ExportPipelineError("Texture baking failed")
+
+        legacy.transfer_baked_uvs_to_segments(
+            textured_obj,
+            session.segment_objects,
+            target_uv_name,
+        )
+
+        results = _export_segments(
+            session.segment_objects,
+            original_copy,
+            textured_obj,
+            texture_width,
+            texture_height,
+            z_groups_info,
+            original_z_groups,
+            save_directory,
+            original_world_location,
+        )
+        merged = legacy.merge_spine_json_dicts(results[0], results[1:])
+        final_path = os.path.join(save_directory, f"{obj.name}_merged.json")
+        legacy.write_json(merged, final_path)
+        logger.info("Export completed: %s", final_path)
+        return final_path
+    except Exception:
+        logger.exception("Fatal error in resource-safe save_uv_as_json")
+        return None
+    finally:
+        try:
+            session.cleanup(preserve_debug)
+        finally:
+            session.restore_source_metadata()
+            session.context.restore()
+
+
+def install(main_module) -> None:
+    """Install v2 implementations behind the legacy ``main`` API."""
+    global _LEGACY_MAIN
+    _LEGACY_MAIN = main_module
+
+    replacements = {
+        "apply_segmentation_seams": apply_segmentation_seams,
+        "copy_orig_face_id_layer": copy_orig_face_id_layer,
+        "get_texture_dimensions": get_texture_dimensions,
+        "triangulate_mesh": triangulate_mesh,
+        "collect_vertices": collect_vertices,
+        "calculate_stretch_values": calculate_stretch_values,
+        "apply_transformations": apply_transformations,
+        "save_uv_as_json": save_uv_as_json,
+    }
+    for name, implementation in replacements.items():
+        setattr(main_module, name, implementation)
+    logger.info("Installed resource-safe export pipeline v2")

--- a/docs/REWRITE_STATUS.md
+++ b/docs/REWRITE_STATUS.md
@@ -1,0 +1,49 @@
+# Staged rewrite status
+
+## v0.24 resource-safety foundation
+
+The public package keeps its existing import surface while export orchestration
+moves out of `main.py` into `pipeline_v2.py`.  `__init__.py` installs the new
+implementations before UI and multi-object modules import the legacy API.
+
+This first slice intentionally does not change the Spine 4.2 JSON schema,
+object/slot/bone naming, segmentation algorithms, UV correspondence format or
+texture bake output.
+
+### Corrected ownership rules
+
+- A BMesh created by `bmesh.new()` has one owner and one `free()` call.
+- `collect_vertices()` borrows a BMesh and never frees it.
+- `_export_segment()` remains the owner of BMeshes returned by
+  `triangulate_mesh()`.
+- The discarded pre-processing triangulation call is removed; export
+  triangulation remains local to the BMeshes owned by `_export_segment()`.
+- Source/target face-ID transfer and segmentation seam application use managed
+  BMeshes with guaranteed cleanup.
+
+### Corrected Blender state rules
+
+- The active object, selection and mode are captured once per export and
+  restored in `finally`.
+- Transform application activates exactly the requested object.
+- Temporary objects are tracked by identity and removed through
+  `bpy.data.objects.remove(..., do_unlink=True)`.
+- Logging level no longer changes cleanup behaviour.  Temporary objects are
+  preserved only when the scene custom property
+  `spine2d_preserve_debug_artifacts` is explicitly true.
+- A temporary source UV layer and `face_id_map` metadata are restored after the
+  export.
+
+## Next slices
+
+1. Move `_export_segment` and mesh correspondence into a geometry/export
+   service with typed result objects.
+2. Split segmentation and UV operations from Blender operators so pure
+   topology logic can be tested without `bpy`.
+3. Replace global texture dimensions with immutable export settings.
+4. Extract baking into a context-managed bake session and support mixed shader
+   graphs.
+5. Add Blender 4.4 headless integration fixtures for mode restoration,
+   temporary datablock cleanup, triangulation and bake context.
+6. Remove the compatibility installer after UI and multi-object export import
+   the new services directly.

--- a/tests/test_main_misc.py
+++ b/tests/test_main_misc.py
@@ -1,6 +1,7 @@
-from Blender_to_Spine2D_Mesh_Exporter import main
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock, patch
 import os
+
+from Blender_to_Spine2D_Mesh_Exporter import main, pipeline_v2
 
 
 class Poly:
@@ -9,32 +10,32 @@ class Poly:
 
 
 class Mesh:
-    def __init__(self, n):
-        self.polygons = [Poly(i) for i in range(n)]
+    def __init__(self, count):
+        self.polygons = [Poly(index) for index in range(count)]
         self.storage = {}
 
-    def __setitem__(self, key, val):
-        self.storage[key] = val
+    def __setitem__(self, key, value):
+        self.storage[key] = value
 
     def __getitem__(self, key):
         return self.storage[key]
 
 
 class Obj:
-    def __init__(self, name, n):
+    def __init__(self, name, count):
         self.name = name
-        self.data = Mesh(n)
+        self.data = Mesh(count)
 
 
 class Image:
-    def __init__(self, w, h):
-        self.size = (w, h)
+    def __init__(self, width, height):
+        self.size = (width, height)
 
 
 class Node:
-    def __init__(self, img=None):
+    def __init__(self, image=None):
         self.type = "TEX_IMAGE"
-        self.image = img
+        self.image = image
 
 
 class NodeTree:
@@ -48,9 +49,9 @@ class Material:
 
 
 class ObjMat(Obj):
-    def __init__(self, name, n, mat):
-        super().__init__(name, n)
-        self.active_material = mat
+    def __init__(self, name, count, material):
+        super().__init__(name, count)
+        self.active_material = material
 
 
 def test_assign_face_ids():
@@ -59,77 +60,68 @@ def test_assign_face_ids():
     assert obj.data["face_id_map"] == {"0": 0, "1": 1, "2": 2}
 
 
-# Duplicate function definition removed
 def test_get_texture_dimensions():
-    img = Image(128, 256)
-    mat = Material([Node(img)])
-    obj = ObjMat("o", 1, mat)
-    w, h = main.get_texture_dimensions(obj, 64, 64)
-    assert (w, h) == (128, 256)
+    image = Image(128, 256)
+    material = Material([Node(image)])
+    obj = ObjMat("o", 1, material)
+    assert main.get_texture_dimensions(obj, 64, 64) == (128, 256)
 
 
 def test_save_uv_as_json_uses_custom_output_dir(tmp_path):
-    """
-    This test checks that save_uv_as_json uses the specified
-    'output_dir' directory to save the final JSON,
-    and not the default directory.
-    """
-    # 1. Setup
+    from contextlib import ExitStack
+
     custom_dir = tmp_path / "custom_json_output"
     custom_dir.mkdir()
 
-    mock_uv_layers = MagicMock()
-    mock_uv_layers.active = MagicMock()
+    source = MagicMock(type="MESH")
+    source.name = "TestCube"
+    source.matrix_world.translation.copy.return_value = (0, 0, 0)
+    source.data.__contains__.return_value = False
 
-    mock_obj = MagicMock()
-    mock_obj.name = "TestCube"
-    mock_obj.type = "MESH"
-    mock_obj.matrix_world.translation.copy.return_value = (0, 0, 0)
-    mock_obj.data.uv_layers = mock_uv_layers
+    working_copy = MagicMock(type="MESH")
+    working_copy.name = "TestCube_copy_for_uv"
+    source.copy.return_value = working_copy
+    source.data.copy.return_value = working_copy.data
 
-    mock_textured_obj = MagicMock()
-    mock_textured_obj.name = "textured_mock"
-    mock_textured_obj.type = "MESH"
-    mock_textured_obj.data.uv_layers = mock_uv_layers
+    textured = MagicMock(type="MESH")
+    textured.name = "TestCube_texturing_copy"
 
-    mock_export_return = {
+    export_result = {
         "bones": [{"name": "root"}],
-        "_uv3d_pairs": [[0, [0.1, 0.1], [0, 0, 0]]],  # Add dummy data
+        "_uv3d_pairs": [[0, [0.1, 0.1], [0, 0, 0]]],
         "textured_uv3d_pairs": [[0, [0.1, 0.1], [0, 0, 0]]],
     }
 
-    with patch(
-        "Blender_to_Spine2D_Mesh_Exporter.main._export_segment",
-        return_value=mock_export_return,
-    ) as mock_export, patch(
-        "Blender_to_Spine2D_Mesh_Exporter.main.merge_spine_json_dicts",
-        return_value={"skeleton": {}},
-    ) as mock_merge, patch(
-        "Blender_to_Spine2D_Mesh_Exporter.main.write_json"
-    ) as mock_write_json, patch(
-        "Blender_to_Spine2D_Mesh_Exporter.main.plane_cut.execute_smart_cut",
-        return_value=[],
-    ), patch(
-        "Blender_to_Spine2D_Mesh_Exporter.main.main_preprocessing",
-        return_value={"z_groups_info": {0.0: {}}},
-    ), patch(
-        "Blender_to_Spine2D_Mesh_Exporter.main.bake_textures_for_object",
-        return_value=True,
-    ), patch(
-        "Blender_to_Spine2D_Mesh_Exporter.main.transfer_baked_uvs_to_segments"
-    ), patch(
-        "Blender_to_Spine2D_Mesh_Exporter.main.mark_seams_on_copy",
-        return_value=(mock_textured_obj, []),
-    ), patch("bpy.context.scene.objects", return_value=[]):
-        # 2. Execution
-        main.save_uv_as_json(mock_obj, 512, 512, output_dir=str(custom_dir))
+    patches = [
+        patch.object(pipeline_v2, "_mesh_object", return_value=source),
+        patch.object(pipeline_v2, "_resolve_output_directory", return_value=str(custom_dir)),
+        patch.object(pipeline_v2, "_ensure_source_uv", return_value="UVMap"),
+        patch.object(pipeline_v2, "_copy_seams"),
+        patch.object(pipeline_v2, "activate_object"),
+        patch.object(pipeline_v2, "_object_ids", return_value=set()),
+        patch.object(pipeline_v2, "_new_segment_objects", return_value=[]),
+        patch.object(pipeline_v2, "apply_segmentation_seams"),
+        patch.object(pipeline_v2, "copy_orig_face_id_layer", return_value=True),
+        patch.object(pipeline_v2, "_prepare_textured_uv", return_value="UVMap_for_texturing"),
+        patch.object(pipeline_v2, "_export_segments", return_value=[export_result]),
+        patch.object(pipeline_v2, "scene_bool", return_value=False),
+        patch.object(pipeline_v2.ExportSession, "cleanup"),
+        patch.object(pipeline_v2.ExportSession, "restore_source_metadata"),
+        patch.object(main, "assign_face_ids"),
+        patch.object(main, "main_preprocessing", return_value={"z_groups_info": {0.0: {}}}),
+        patch.object(main.plane_cut, "execute_smart_cut", return_value=[]),
+        patch.object(main, "mark_seams_on_copy", return_value=(textured, [])),
+        patch.object(main, "bake_textures_for_object", return_value=True),
+        patch.object(main, "transfer_baked_uvs_to_segments"),
+        patch.object(main, "merge_spine_json_dicts", return_value={"skeleton": {}}),
+        patch.object(main, "write_json"),
+    ]
 
-        # 3. Verification
-        mock_write_json.assert_called_once()
+    with ExitStack() as stack:
+        entered = [stack.enter_context(item) for item in patches]
+        write_json = entered[-1]
+        result = main.save_uv_as_json(source, 512, 512, output_dir=str(custom_dir))
 
-        call_args = mock_write_json.call_args
-        final_path = call_args[0][1]
-
-        expected_path = os.path.join(str(custom_dir), f"{mock_obj.name}_merged.json")
-
-        assert final_path == expected_path
+    expected_path = os.path.join(str(custom_dir), "TestCube_merged.json")
+    assert result == expected_path
+    write_json.assert_called_once_with({"skeleton": {}}, expected_path)

--- a/tests/test_pipeline_v2_safety.py
+++ b/tests/test_pipeline_v2_safety.py
@@ -1,0 +1,88 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from Blender_to_Spine2D_Mesh_Exporter import blender_context, main, pipeline_v2
+
+
+def test_pipeline_is_installed_behind_legacy_main_api():
+    assert main.save_uv_as_json is pipeline_v2.save_uv_as_json
+    assert main.collect_vertices is pipeline_v2.collect_vertices
+    assert main.triangulate_mesh is pipeline_v2.triangulate_mesh
+
+
+def test_managed_bmesh_writes_back_and_frees_exactly_once():
+    mesh = MagicMock()
+    bm = MagicMock()
+
+    with patch.object(blender_context.bmesh, "new", return_value=bm):
+        with blender_context.managed_bmesh(mesh, write_back=True) as yielded:
+            assert yielded is bm
+
+    bm.from_mesh.assert_called_once_with(mesh)
+    bm.to_mesh.assert_called_once_with(mesh)
+    bm.free.assert_called_once_with()
+    mesh.update.assert_called_once_with()
+
+
+def test_managed_bmesh_frees_on_exception_without_partial_writeback():
+    mesh = MagicMock()
+    bm = MagicMock()
+
+    with patch.object(blender_context.bmesh, "new", return_value=bm):
+        with pytest.raises(RuntimeError):
+            with blender_context.managed_bmesh(mesh, write_back=True):
+                raise RuntimeError("boom")
+
+    bm.to_mesh.assert_not_called()
+    bm.free.assert_called_once_with()
+
+
+def test_triangulate_mesh_transfers_ownership_to_caller():
+    obj = MagicMock(type="MESH")
+    obj.name = "Mesh"
+    bm = MagicMock()
+    bm.faces = [MagicMock()]
+
+    with patch.object(pipeline_v2.bmesh, "new", return_value=bm), patch.object(
+        pipeline_v2.bmesh.ops, "triangulate"
+    ) as triangulate:
+        result = pipeline_v2.triangulate_mesh(obj)
+
+    assert result is bm
+    bm.from_mesh.assert_called_once_with(obj.data)
+    triangulate.assert_called_once()
+    bm.free.assert_not_called()
+
+
+def test_triangulate_mesh_frees_when_triangulation_fails():
+    obj = MagicMock(type="MESH")
+    obj.name = "Mesh"
+    bm = MagicMock()
+    bm.faces = [MagicMock()]
+
+    with patch.object(pipeline_v2.bmesh, "new", return_value=bm), patch.object(
+        pipeline_v2.bmesh.ops,
+        "triangulate",
+        side_effect=RuntimeError("invalid topology"),
+    ):
+        with pytest.raises(RuntimeError):
+            pipeline_v2.triangulate_mesh(obj)
+
+    bm.free.assert_called_once_with()
+
+
+def test_collect_vertices_does_not_free_borrowed_bmesh():
+    bm = MagicMock()
+    bm.loops.layers.uv.active = None
+
+    with pytest.raises(pipeline_v2.ExportPipelineError):
+        pipeline_v2.collect_vertices(bm, "Mesh")
+
+    bm.free.assert_not_called()
+
+
+def test_get_texture_dimensions_uses_defaults_for_missing_material():
+    obj = MagicMock()
+    obj.active_material = None
+    assert pipeline_v2.get_texture_dimensions(obj, 256, 128) == (256, 128)


### PR DESCRIPTION
## What changed

This is the first staged rewrite slice for the public add-on.

- Added `blender_context.py` with explicit Blender context restoration and a managed `bmesh.new()` lifecycle.
- Added `pipeline_v2.py` as a compatibility bridge behind the existing `main` API.
- Replaced unsafe implementations of seam application, `orig_face_id` transfer, texture-size detection, BMesh triangulation/collection, stretch calculation, transformation application and `save_uv_as_json` orchestration.
- Removed the discarded pre-processing triangulation call that leaked a BMesh without changing the Mesh datablock.
- Made temporary-object cleanup independent from logging level.
- Restored active object, selection, mode, temporary source UV metadata and `face_id_map` in `finally`.
- Tracks only objects created during the current cut operation instead of deleting all scene objects matching a name prefix.
- Bumped the add-on/manifest version to `0.24.0`.
- Added focused ownership and compatibility tests plus a staged rewrite status document.

## Compatibility intent

This slice intentionally keeps the existing Spine 4.2 JSON schema, bone/slot/object naming, segmentation algorithms, UV correspondence data, baking calls, operator identifiers and public imports. `__init__.py` installs the new functions before UI and multi-object modules import the legacy API.

## Root causes addressed

- `collect_vertices()` freed caller-owned BMeshes and `_export_segment()` freed them again.
- several `bmesh.new()` paths did not guarantee `free()` on exceptions.
- the initial `triangulate_mesh(original_copy)` result was discarded.
- DEBUG logging changed functional cleanup behavior and left temporary objects in the scene.
- context-sensitive operators assumed the correct active object and mode.
- cleanup selected segment objects globally by name rather than by objects created by the current export.

## Validation performed

- Python bytecode compilation for every changed Python file.
- Isolated BMesh ownership tests with controlled `bpy`/`bmesh` modules.
- Verified successful write-back/free and failure-path free behavior.
- Verified `collect_vertices()` does not free a borrowed BMesh.
- Verified transition API installation through the package bootstrap.
- Verified committed blob SHAs against the locally validated files.
- Repository CI passed on Python 3.10 and Python 3.11.

## Validation still required before merge

A real Blender 4.4 headless run is not available in the current execution environment. Before merge, run the add-on in Blender against representative plane/cube/cylinder/custom-seam/material/multi-object fixtures and confirm generated JSON/texture parity with v0.23.

## Known next slice

Move `_export_segment()` itself into the managed geometry/export layer. Its current legacy allocation order can still leave the first BMesh alive if creation of the second BMesh fails before entering its `try/finally` block.